### PR TITLE
fix: search table filter field

### DIFF
--- a/src/components/SearchTable.js
+++ b/src/components/SearchTable.js
@@ -45,6 +45,7 @@ class C_SearchTable extends Component {
           showPagination={true}
           rowsPerPage={this.state.rowsPerPage}
           hasFilter={true}
+          filterPadding={true}
         >
         </C_Table>
       </div>

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -163,7 +163,11 @@ export class C_Table extends React.Component {
           {this.state.showPagination
             ? <TableFooter style={{ position: "relative", className: "md-grid" }}>
                 { this.state.hasFilter ?
-                  <tr style={{ position: "absolute", bottom: 0, left: 10, width: 500 }}>
+                  <tr style={{
+                    position: "absolute",
+                    ...(this.props.filterPadding ? { paddingLeft: 10 } : { bottom: 0, left: 10 }),
+                    width: 500
+                  }}>
                     <td>
                     <C_TextField
                       id="filter"


### PR DESCRIPTION
## Description
This PR fixes the filter field in search table.
For some reason when we filter in some CRUD, it bugs the absolute position and puts the field in the bottom of the screen.
To solve this, I added new prop to search table that defines if use 'bottom' and 'left' property or just a 'padding left'.

### Before this fix:

Dashboard:
![image](https://user-images.githubusercontent.com/34343596/99187132-81d57f00-2733-11eb-8608-c63d89efd216.png)

Crud:
![image](https://user-images.githubusercontent.com/34343596/99187146-93b72200-2733-11eb-886d-062f2a595905.png)

### After this fix:

Dashboard:
![dashboard](https://user-images.githubusercontent.com/34343596/99187100-55b9fe00-2733-11eb-9eed-3c79cd4f93ac.png)

Crud:
![image](https://user-images.githubusercontent.com/34343596/99187108-65394700-2733-11eb-8f22-7e5084712ac4.png)